### PR TITLE
Add counter cache to comments

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -28,7 +28,7 @@ class Article < ActiveRecord::Base
   end
 
   def self.most_popular
-    all.sort_by{|a| a.comments.count }.last
+    all.sort_by{|a| a.comments.size }.last
   end
 
   def self.random

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
-  belongs_to :article
+  belongs_to :article, :counter_cache => true
 
   validates :article_id, :presence => true
 

--- a/db/migrate/20170916173432_add_comments_count_to_articles.rb
+++ b/db/migrate/20170916173432_add_comments_count_to_articles.rb
@@ -1,0 +1,7 @@
+class AddCommentsCountToArticles < ActiveRecord::Migration
+  def change
+    change_table :articles do |t|
+      t.integer :comments_count, default: 0
+    end
+  end
+end

--- a/db/migrate/20170916184246_add_index_to_comments.rb
+++ b/db/migrate/20170916184246_add_index_to_comments.rb
@@ -1,0 +1,7 @@
+class AddIndexToComments < ActiveRecord::Migration
+  def change
+    change_table :comments do |t|
+      t.index :article_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130408190802) do
+ActiveRecord::Schema.define(version: 20170916184246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20130408190802) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "author_id"
+    t.integer  "comments_count", default: 0
   end
 
   create_table "authors", force: true do |t|
@@ -41,6 +42,8 @@ ActiveRecord::Schema.define(version: 20130408190802) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "comments", ["article_id"], name: "index_comments_on_article_id", using: :btree
 
   create_table "taggings", force: true do |t|
     t.integer  "article_id"

--- a/lib/tasks/counter_cache.rake
+++ b/lib/tasks/counter_cache.rake
@@ -1,0 +1,5 @@
+desc 'Updates comments_count for articles'
+
+task update_comments_count: :environment do
+  ActiveRecord::Base.connection.execute("UPDATE articles SET comments_count = (SELECT count(1) FROM comments WHERE comments.article_id = articles.id)")
+end


### PR DESCRIPTION
1. Adding an index to the article_id then creating a counter_cache for the comments greatly improves the search for the most popular article. Since the articles & comments already exist in the database we need to seed the comments_count information. We can do that using the `update_comments_count` rake task

2. Some things I would point the student to look at would be:
- look at eager loading using includes in regards to comments and articles
- fragment caching the counts
- catching some of the data: i.e most popular article
- keeping count of word in article and comment on the modal so you can just pluck the count and sum it rather than counting all the words each time